### PR TITLE
Fix slave_color format for colors < 100000

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -48,7 +48,7 @@ class smokeping::config {
       ## Slave configuration
       'slave': {
           if $smokeping::slave_display_name == '' { $display_name = $::hostname }
-          if $smokeping::slave_color == '' { $slave_color = fqdn_rand('999999') }
+          if $smokeping::slave_color == '' { $slave_color = sprintf('%06d', fqdn_rand('999999')) }
           smokeping::slave { $::hostname:
               location     => $smokeping::slave_location,
               display_name => $display_name,


### PR DESCRIPTION
`fqdn_rand('999999')` produces numbers with less than 6 digits, but smokeping only supports 6-digit color definitions.
This patch ensures that the slave_color parameter is always 6 digits.
