### PR TITLE
Add support for empty "alerts =" lines in targets.

### DIFF
--- a/manifests/target.pp
+++ b/manifests/target.pp
@@ -36,7 +36,7 @@ define smokeping::target (
     $hierarchy_parent = '',
     $probe = '',
     $host = '',
-    $alerts = [],
+    $alerts = false,
     $slaves = [],
     $nomasterpoll = false,
     $remark = '',

--- a/templates/target.erb
+++ b/templates/target.erb
@@ -12,7 +12,7 @@ title = <%= menu %>
 <% if host != '' then -%>
 host = <%= host %>
 <% end -%>
-<% if alerts != [] then -%>
+<% if alerts != false then -%>
 alerts = <%= alerts.join(',') %>
 <% end -%>
 <% if nomasterpoll then -%>


### PR DESCRIPTION
Tested in our infrastructure to fix the issue reported in #6.
