### PR TITLE
added options param to smokeping::target

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -8,4 +8,5 @@ description 'Puppet module to completely manage a SmokePing installation. Includ
 project_page 'https://github.com/tobru/puppet-smokeping'
 
 ## Add dependencies, if any:
-dependency 'ripienaar/concat'
+dependency 'puppetlabs/concat'
+dependency 'puppetlabs/stdlib'

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Some background information can be found here: [Puppet module to manage SmokePin
 Tested on Ubuntu 12.04 LTS
 
 ## Dependencies
-  - [puppet-concat](https://github.com/ripienaar/puppet-concat)
+  - [puppetlabs-concat](https://github.com/puppetlabs/puppet-concat)
+  - [puppetlabs-stdlib](https://github.com/puppetlabs/puppet-stdlib)
 
 ## Example
 
@@ -114,6 +115,16 @@ smokeping::target { 'GoogleCHIPv6':
     host             => 'google.ch',
     probe            => 'FPing6'
     slaves           => ['slave1'],
+}
+smokeping::target { 'GoogleCHCurl':
+    hierarchy_parent => 'GoogleCH',
+    hierarchy_level  => 3,
+    menu             => 'google.ch Curl',
+    host             => 'google.ch',
+    probe            => 'Curl',
+    options          => {
+      urlformat => 'http://%host%/',
+    }
 }
 ```
 

--- a/manifests/target.pp
+++ b/manifests/target.pp
@@ -40,7 +40,18 @@ define smokeping::target (
     $slaves = [],
     $nomasterpoll = false,
     $remark = '',
+    $options = {},
 ) {
+    validate_string( $pagetitle )
+    validate_string( $menu )
+    validate_string( $hierarchy_parent )
+    validate_string( $probe )
+    validate_string( $host )
+    validate_array( $alerts )
+    validate_array( $slaves )
+    validate_bool( $nomasterpoll )
+    validate_string( $remark )
+    validate_hash( $options )
 
     $filename = "${smokeping::targets_dir}/${hierarchy_level}-${name}"
     concat { $filename:

--- a/templates/target.erb
+++ b/templates/target.erb
@@ -24,4 +24,10 @@ slaves = <%= slaves.join(' ') %>
 <% if remark != '' then -%>
 remark = <%= remark %>
 <% end -%>
+<% if options then -%>
+<%- options.sort.each do |key,value| -%>
+<%= key %> = <%= value %>
+<%- end -%>
+<% end -%>
+
 


### PR DESCRIPTION
Some probes require additional options to be passed to the target
configuration; now you can pass an arbitrary hash in, and the key-value
pairs will be appended to the target configuration file.  See README for
an example.

Also added parameter validation for smokeping::target.
