### PR TITLE
Use validate_re to detect whitespace in title

### DIFF
--- a/manifests/target.pp
+++ b/manifests/target.pp
@@ -42,6 +42,7 @@ define smokeping::target (
     $remark = '',
     $options = {},
 ) {
+    validate_re( $name, '^[^[:space:]]+$', 'Target name cannot contain whitespace.' )
     validate_string( $pagetitle )
     validate_string( $menu )
     validate_string( $hierarchy_parent )


### PR DESCRIPTION
If you create a `smokeping::target` resource whose name contains whitespace, the manifest will compile, but it will create a file with whitespace in the filename, which makes SmokePing throw an error.

This pull request includes a `validate_re()` call so that such resources will cause the manifest to fail compilation.
