### PR TITLE
Allow setting the step for FPing Probes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -141,7 +141,7 @@ class smokeping(
     $cgiurl             = 'http://some.url/smokeping.cgi',
     $syslogfacility     = 'local0',
     $syslogpriority     = 'info',
-    $probes             = [ { name => 'FPing', binary => '/usr/bin/fping' } ],
+    $probes             = [ { name => 'FPing', binary => '/usr/bin/fping', step => '300' } ],
     $default_probe      = 'FPing',
     $alerts_to          = 'alertee@address.somewhere',
     $alerts_from        = 'smokealert@company.xy',

--- a/templates/probes.erb
+++ b/templates/probes.erb
@@ -5,5 +5,6 @@
 <% probes.each do |probe| -%>
 + <%= probe['name'] %>
 binary = <%= probe['binary'] %>
+step = <%= probe['step'] %>
 
 <% end -%>


### PR DESCRIPTION
Add "step" as a default value set to 300 but allow users to override.
