### PR TITLE
Allow arbitrary probe config values

### DIFF
--- a/templates/probes.erb
+++ b/templates/probes.erb
@@ -3,8 +3,9 @@
 # THIS FILE IS MANAGED BY PUPPET
 
 <% probes.each do |probe| -%>
-+ <%= probe['name'] %>
-binary = <%= probe['binary'] %>
-step = <%= probe['step'] %>
++ <%= probe.delete('name') %>
+<% probe.each_pair do |k,v| -%>
+<%= k %> = <%= v %>
+<% end -%>
 
 <% end -%>


### PR DESCRIPTION
This changes the statically configured options for binary and step to
allow configuring any probe configuration that is passed in the hash by
the user.  This is needed for probes like AnotherDNS that have no binary
option, but have other useful options.
