### PR TITLE
Require smokeping installed before creating dirs

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,16 +17,19 @@ class smokeping::install {
             ensure  => directory,
             owner   => $smokeping::daemon_user,
             group   => $smokeping::daemon_group,
+            require => Package['smokeping'],
             recurse => true;
         $smokeping::path_piddir:
             ensure  => directory,
             owner   => $smokeping::daemon_user,
             group   => $smokeping::daemon_group,
+            require => Package['smokeping'],
             recurse => true;
         $smokeping::path_imgcache:
             ensure  => directory,
             owner   => $smokeping::webserver_user,
             group   => $smokeping::webserver_group,
+            require => Package['smokeping'],
             recurse => true;
     }
 


### PR DESCRIPTION
On Ubuntu, the smokeping user is created by the package, so this patch
adds a dependency that requires the package be installed before creating
directories that are owned by the user.
