### PR TITLE
Allow leaving out of alerts parameter (empty array instead of false by default)

### DIFF
--- a/manifests/target.pp
+++ b/manifests/target.pp
@@ -36,7 +36,7 @@ define smokeping::target (
     $hierarchy_parent = '',
     $probe = '',
     $host = '',
-    $alerts = false,
+    $alerts = [],
     $slaves = [],
     $nomasterpoll = false,
     $remark = '',

--- a/templates/target.erb
+++ b/templates/target.erb
@@ -12,7 +12,7 @@ title = <%= menu %>
 <% if host != '' then -%>
 host = <%= host %>
 <% end -%>
-<% if alerts != false then -%>
+<% if ! alerts.empty? then -%>
 alerts = <%= alerts.join(',') %>
 <% end -%>
 <% if nomasterpoll then -%>


### PR DESCRIPTION
I wasn't able to skip putting the "alerts:" element into a hiera file which then used create_resources to make smokeping::target calls without this.

It's only a very small patch  :)
