### PR TITLE
Bump minimum version dependencies (for Puppet 4)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,11 +15,11 @@
     }
   ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" },
-    { "name": "puppetlabs/concat", "version_requirement": ">= 1.0.0 <3.0.0" },
-    { "name": "puppetlabs/apache", "version_requirement": ">= 1.0.0 <2.0.0" },
-    { "name": "puppetlabs/firewall", "version_requirement": ">= 1.0.0 <2.0.0" },
-    { "name": "puppet/selinux", "version_requirement": ">= 0.4.1 <1.0.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=4.6.0 <5.0.0" },
+    { "name": "puppetlabs/concat", "version_requirement": ">= 1.2.5 <3.0.0" },
+    { "name": "puppetlabs/apache", "version_requirement": ">= 1.6.0 <2.0.0" },
+    { "name": "puppetlabs/firewall", "version_requirement": ">= 1.7.0 <2.0.0" },
+    { "name": "puppet/selinux", "version_requirement": ">= 0.5.0 <1.0.0" }
   ],
   "requirements": [
     {


### PR DESCRIPTION
Bump dependencies to the minimum version that should work
under Puppet 4, based on the metadata