### PR TITLE
hierarchy_parent and remark variables validation fails if they are no…

### DIFF
--- a/manifests/target.pp
+++ b/manifests/target.pp
@@ -32,10 +32,10 @@
 define smokeping::target (
   String $pagetitle,
   String $menu,
-  String $hierarchy_parent,
+  String $hierarchy_parent = '',
   String $probe,
   String $host,
-  String $remark,
+  String $remark = '',
   Integer $hierarchy_level = 1,
   Array $alerts            = [],
   Array $slaves            = [],


### PR DESCRIPTION
…t defined

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
This should fix https://github.com/voxpupuli/puppet-smokeping/issues/74