### PR TITLE
Empty string default for ariables 'remark' and 'hierarchy_parent'

### DIFF
--- a/manifests/target.pp
+++ b/manifests/target.pp
@@ -32,10 +32,10 @@
 define smokeping::target (
   String $pagetitle,
   String $menu,
-  String $hierarchy_parent,
   String $probe,
   String $host,
-  String $remark,
+  String $hierarchy_parent = '',
+  String $remark           = '',
   Integer $hierarchy_level = 1,
   Array $alerts            = [],
   Array $slaves            = [],


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
If variables remark and hierarchy_parent are not defined, module fails when validating these to be a string. This patch provides default values for these variables.