### PR TITLE
Fix: no implicit conversion of Fixnum into String

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -25,12 +25,12 @@ define smokeping::slave(
     mode    => '0644',
   }
 
-  $random_value = fqdn_rand(1000000)
+  $random_value = fqdn_rand_string(60, 'abcdefghjkelmnopqrstuvwxyaABCDEFGHJKELMNOPQRSTUVWXYA0123456789')
   file { $smokeping::shared_secret:
       mode    => '0600',
       owner   => $smokeping::daemon_user,
       group   => $smokeping::daemon_group,
-      content => "${random_value}",
+      content => $random_value,
   }
   @@concat::fragment { "${::fqdn}-secret":
       target  => $smokeping::slave_secrets,

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -30,7 +30,7 @@ define smokeping::slave(
       mode    => '0600',
       owner   => $smokeping::daemon_user,
       group   => $smokeping::daemon_group,
-      content => $random_value,
+      content => "${random_value}",
   }
   @@concat::fragment { "${::fqdn}-secret":
       target  => $smokeping::slave_secrets,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Fix error for slave instance:
Error: Failed to apply catalog: Parameter content failed on File[/etc/smokeping/slavesecrets.conf]: Munging failed for value 479121 in class content: no implicit conversion of Fixnum into String at /etc/puppetlabs/code/environments/development/modules/smokeping/manifests/slave.pp:29

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
