### PR TITLE
Fix: fqdn -> slave_name

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -112,6 +112,7 @@ class smokeping::config {
       }
 
       smokeping::slave { $::fqdn:
+        slave_name   => $slave_name,
         location     => $smokeping::slave_location,
         display_name => $display_name,
         color        => $slave_color,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class smokeping::params {
     $master_url         = 'http://somewhere/cgi-bin/smokeping.cgi'
     $shared_secret      = '/etc/smokeping/slavesecrets.conf'
     $slave_secrets      = '/etc/smokeping/smokeping_secrets'
-    $slave_name         = $fqdn
+    $slave_name         = $::fqdn
     $slave_dir          = '/etc/smokeping/config.d/slaves.d'
     $slave_location     = ''
     $slave_display_name = ''

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class smokeping::params {
     $master_url         = 'http://somewhere/cgi-bin/smokeping.cgi'
     $shared_secret      = '/etc/smokeping/slavesecrets.conf'
     $slave_secrets      = '/etc/smokeping/smokeping_secrets'
-    $slave_name         = $::fqdn
+    $slave_name         = $facts['fqdn']
     $slave_dir          = '/etc/smokeping/config.d/slaves.d'
     $slave_location     = ''
     $slave_display_name = ''

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class smokeping::params {
     $master_url         = 'http://somewhere/cgi-bin/smokeping.cgi'
     $shared_secret      = '/etc/smokeping/slavesecrets.conf'
     $slave_secrets      = '/etc/smokeping/smokeping_secrets'
-    $slave_name         = 'slave1'
+    $slave_name         = $fqdn
     $slave_dir          = '/etc/smokeping/config.d/slaves.d'
     $slave_location     = ''
     $slave_display_name = ''

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -16,7 +16,7 @@
 #   Name of the smokeping master, in case there are more than one. (Default: default)
 #
 define smokeping::slave(
-    $slave_name = $::smokeping::params::slave_name,
+    $slave_name,
     $location,
     $display_name,
     $color,

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -13,6 +13,7 @@
 #   Name of the smokeping master, in case there are more than one. (Default: default)
 #
 define smokeping::slave(
+    $slave_name,
     $location,
     $display_name,
     $color,
@@ -32,14 +33,14 @@ define smokeping::slave(
       group   => $smokeping::daemon_group,
       content => $random_value,
   }
-  @@concat::fragment { "${::fqdn}-secret":
+  @@concat::fragment { "${slave_name}-secret":
       target  => $smokeping::slave_secrets,
       order   => 10,
-      content => "${::fqdn}:${random_value}\n",
+      content => "${slave_name}:${random_value}\n",
       tag     => "smokeping-slave-secret-${master}",
   }
 
-  $filename = "${smokeping::slave_dir}/${::fqdn}"
+  $filename = "${smokeping::slave_dir}/${slave_name}"
   @@file { $filename:
       content => template('smokeping/slave.erb'),
       tag     => "smokeping-slave-${master}",

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -16,7 +16,7 @@
 #   Name of the smokeping master, in case there are more than one. (Default: default)
 #
 define smokeping::slave(
-    $slave_name,
+    $slave_name = $::smokeping::params::slave_name,
     $location,
     $display_name,
     $color,

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -3,8 +3,11 @@
 # [*slave*]
 #   Location of slave
 #
+# [*slave_name*]
+#   Name of the slave for config files
+#
 # [*display_name*]
-#   Name of the slave
+#  The name of the slave server that will be displayed in the web interface
 #
 # [*color*]
 #   Color of this slave

--- a/templates/defaults.erb
+++ b/templates/defaults.erb
@@ -7,5 +7,5 @@ DAEMON_USER=<%= @daemon_user %>
 <% if @mode == 'slave' then -%>
 MASTER_URL=<%= @master_url %>
 SHARED_SECRET=<%= @shared_secret %>
-SLAVE_NAME=<%= @fqdn %>
+SLAVE_NAME=<%= @slave_name %>
 <% end -%>

--- a/templates/slave.erb
+++ b/templates/slave.erb
@@ -1,6 +1,6 @@
 # THIS FILE IS MANAGED BY PUPPET
 
-+ <%= @name %>
++ <%= @slave_name %>
 display_name = <%= @display_name %>
 color = <%= @color %>
 location = <%= @location %>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The "slave_name" parameter does not work. If you specify it, `$fqdn` will still be used everywhere.
I added this parameter to `smokeping::slave`. The default is `$fqdn`, otherwise `$slave_name`.

