### PR TITLE
Fix smokeping::target type

### DIFF
--- a/manifests/target.pp
+++ b/manifests/target.pp
@@ -30,12 +30,12 @@
 #   Remark displayed on Website
 #
 define smokeping::target (
-  String $pagetitle,
-  String $menu,
-  String $hierarchy_parent,
-  String $probe,
-  String $host,
-  String $remark,
+  Optional[String[1]] $pagetitle        = undef,
+  Optional[String[1]] $menu             = undef,
+  Optional[String[1]] $hierarchy_parent = undef,
+  Optional[String[1]] $probe            = undef,
+  Optional[String[1]] $host             = undef,
+  Optional[String[1]] $remark           = undef,
   Integer $hierarchy_level = 1,
   Array $alerts            = [],
   Array $slaves            = [],
@@ -68,7 +68,7 @@ define smokeping::target (
         }
         } else {
             #all other levels
-            if $hierarchy_parent == '' {
+            unless $hierarchy_parent {
                 fail('hierarchy_parent has to be specified for levels > 1')
             }
             $parent_level = $hierarchy_level - 1

--- a/templates/target.erb
+++ b/templates/target.erb
@@ -1,33 +1,31 @@
 <%= '+' * @hierarchy_level.to_i %> <%= @name %>
-<% if @probe != '' then -%>
+<% if @probe then -%>
 probe = <%= @probe %>
 <% end -%>
 
 menu = <%= @menu %>
-<% if @pagetitle != '' then -%>
+<% if @pagetitle then -%>
 title = <%= @pagetitle %>
 <% else -%>
 title = <%= @menu %>
 <% end -%>
-<% if @host != '' then -%>
+<% if @host then -%>
 host = <%= @host %>
 <% end -%>
-<% if ! @alerts.empty? then -%>
+<% unless @alerts.empty? then -%>
 alerts = <%= @alerts.join(',') %>
 <% end -%>
 <% if @nomasterpoll then -%>
 nomasterpoll = yes
 <% end -%>
-<% if @slaves != [] then -%>
+<% unless @slaves.empty? then -%>
 slaves = <%= @slaves.join(' ') %>
 <% end -%>
-<% if @remark != '' then -%>
+<% if @remark then -%>
 remark = <%= @remark %>
 <% end -%>
-<% if @options then -%>
 <%- @options.sort.each do |key,value| -%>
 <%= key %> = <%= value %>
 <%- end -%>
-<% end -%>
 
 


### PR DESCRIPTION
fixes #74

https://github.com/voxpupuli/puppet-smokeping/pull/70 introduced a
regression.  Several parameters were made mandatory (previously they
defaulted to an empty string.)

They are now `Optional` and default to `undef`.

**This is a breaking change as empty strings are no longer allowed.**