### PR TITLE
Add EL7 operating systems to metadata.json

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 # === Parameters
 # [*mode*]
-#   SmokePing mode: master or slave or standalone (Default: master)
+#   SmokePing mode: master or slave or standalone (Default: master on ubuntu, standalone on redhat)
 #
 # [*master_url*]
 #   URL to master cgi for slave mode (Default: http://somewhere/cgi-bin/smokeping.cgi)
@@ -120,13 +120,14 @@
 #
 # [*start*]
 #   Should the service be started by Puppet? (Default: true)
-# [*smanage_apache*]
+#
+# [*manage_apache*]
 #   Should we manage the Apache config with puppetlabs/apache? (Default: false)
 #
-# [*smanage_firewall*]
+# [*manage_firewall*]
 #   Should we manage a firewall rule for Smokeping with puppetlabs/firewall? (Default: false)
 #
-# [*smanage_selinux*]
+# [*manage_selinux*]
 #   Should we load an SELinux policy to allow Smokeping to work on Red Hat distros? (Default: false)
 #
 # === Author

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,6 @@ class smokeping::params {
     $enable             = true
     $start              = true
 
-    $mode               = 'master'
     $master_url         = 'http://somewhere/cgi-bin/smokeping.cgi'
     $shared_secret      = '/etc/smokeping/slavesecrets.conf'
     $slave_secrets      = '/etc/smokeping/smokeping_secrets'
@@ -50,8 +49,9 @@ class smokeping::params {
 
     # The major cross-platform differences consist of user account variations
     # and where files reside on disk:
-    if $::osfamily == 'Debian' or $::operatingsystem == 'Ubuntu' {
+    if $::osfamily == 'Debian' {
 
+      $mode               = 'master'
       $daemon_user        = 'smokeping'
       $daemon_group       = 'smokeping'
       $path_sendmail      = '/usr/sbin/sendmail'
@@ -77,6 +77,7 @@ class smokeping::params {
       # Note that many thirdparty Smokeping RPMs for EL tend to be rebuilds of
       # the Fedora one, so best to fix in Fedora first, then tackle the other
       # third party repositories.
+      $mode               = 'standalone'
       $daemon_user        = 'root'
       $daemon_group       = 'root'
 

--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,18 @@
       "operatingsystemrelease": [
         "14.04"
       ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "7"
+      ]
     }
   ],
   "dependencies": [


### PR DESCRIPTION
Currently, master/slave operation isn't supported, so mode should default
to `standalone` for the `RedHat` family.