### PR TITLE
Fix selinux::module parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -201,8 +201,8 @@ class smokeping(
   if $manage_selinux {
     if $::osfamily == 'RedHat' {
       selinux::module { 'local_smokeping':
-        ensure => 'present',
-        source => 'puppet:///modules/smokeping/local_smokeping.te',
+        ensure    => 'present',
+        source_te => 'puppet:///modules/smokeping/local_smokeping.te',
       }
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -52,7 +52,7 @@
     },
     {
       "name": "puppet/selinux",
-      "version_requirement": ">= 0.5.0 < 2.0.0"
+      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
In puppet-selinux v1.0.0 source parameter in selinux::module changed to
source_te parameter.
