### PR TITLE
Support puppetlabs-apache 5.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">= 1.6.0 < 5.0.0"
+      "version_requirement": ">= 1.6.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
Doesn't appear to be any breaking changes going to the latest
version of puppetlabs-apache (v5.5.0 currently), so bump the
upper constraint to `< 6.0.0`.

Fixes #125 
