### PR TITLE
Update dependencies to support latest puppetlabs-firewall

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -44,7 +44,7 @@
     },
     {
       "name": "puppetlabs/firewall",
-      "version_requirement": ">= 1.7.0 < 2.0.0"
+      "version_requirement": ">= 1.7.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
Current version is v2.5.0, so bump the deps to support < 3.0.0

Fixes #128 