### PR TITLE
README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,90 @@
 # SmokePing Puppet module
 
 Puppet module to completely manage a SmokePing installation.
-Includes managing of Master/Slave installation and the menu hierarchy.
+Includes managing of Master/Slave or Standalone installation, and the menu hierarchy.
 
 Some background information can be found here: [Puppet module to manage SmokePing](http://tobrunet.ch/2013/02/puppet-module-to-manage-smokeping/)
 
 ## Features
 
-* Master/Slave/Standalone SmokePing configuration possible
-* Menu hierarchy implemented
-* Define Probes and Alert patterns
-* Config files managed with templates
-* Uses exported resources to configure Slaves on the Master (tag: smokeping-slave)
-* Automatically generates a shared secret for Master/Slave configuration (tag: smokeping-slave-secret)
-
+- Master/Slave/Standalone SmokePing configuration possible
+- Menu hierarchy implemented
+- Define Probes and Alert patterns
+- Config files managed with templates
+- Uses exported resources to configure Slaves on the Master (tag: smokeping-slave)
+- Automatically generates a shared secret for Master/Slave configuration (tag: smokeping-slave-secret)
 
 ## Supported Platforms
 
 Fully supported:
-* Ubuntu (Tested on 12.04, 14.04)
 
-Standalone Only (no master/slave support yet):
-* Fedora 22+
-* CentOS 7+ (Note: requires third party repository to provide smokeping package).
+- Debian, Ubuntu
 
+Standalone only (no master/slave support yet):
+
+- Fedora 22+
+- CentOS 7+ (Note: requires third party repository to provide smokeping package).
 
 ## Dependencies
-  - [puppetlabs-concat](https://github.com/puppetlabs/puppet-concat)
-  - [puppetlabs-stdlib](https://github.com/puppetlabs/puppet-stdlib)
+
+- [puppetlabs-concat](https://github.com/puppetlabs/puppet-concat)
+- [puppetlabs-stdlib](https://github.com/puppetlabs/puppet-stdlib)
 
 ## Example
 
 ### Standalone SmokePing instance
+
 ```puppet
 # install a standalone instance on a server with default values (see init.pp for
 # parameter documentation
-class { '::smokeping':
-    mode => 'standalone',
+class { 'smokeping':
+  mode => 'standalone',
 }
 ```
 
 ### Master SmokePing instance
+
 ```puppet
 # install a master instance on a server with default values (see init.pp for
 # parameter documentation. You must have a slave, or this will not work!
-class { '::smokeping':
-    mode => 'master',
+class { 'smokeping':
+  mode => 'master',
 }
 ```
 
 ### Slave SmokePing instance
+
 ```puppet
-class { '::smokeping':
-    mode           => 'slave',
-    slave_name     => $::hostname,
-    master_url     => 'http://myserver.tld/smokeping/smokeping.cgi',
-    slave_location => 'zurich',
+class { 'smokeping':
+  mode           => 'slave',
+  slave_name     => $facts['hostname'],
+  master_url     => 'http://myserver.tld/smokeping/smokeping.cgi',
+  slave_location => 'zurich',
 }
 ```
+
 This configures the server as slaves and adds the slave definition automatically to the
 master using exported resources.
 
 ### Probes
+
 ```puppet
-$probes = [
-    { name => 'FPing', binary => '/usr/bin/fping' },
-    { name => 'FPing6', binary => '/usr/bin/fping6' },
-]
-Class['::smokeping'] {
-  probes => $probes
+Class['smokeping'] {
+  probes => [
+    {
+      name => 'FPing',
+      binary => '/usr/bin/fping',
+    },
+    {
+      name => 'FPing6',
+      binary => '/usr/bin/fping6',
+    },
+  ],
 }
 ```
 
 ### Alerts
+
 ```puppet
 $alerts = [
   {
@@ -97,50 +109,54 @@ $alerts = [
     comment     => 'there was loss and now its reachable again',
   },
 ]
-Class['::smokeping'] {
+Class['smokeping'] {
   alerts => $alerts,
 }
 ```
 
 ### Targets
+
 ```puppet
 # Top Level
 smokeping::target { 'World':
-    menu      => 'World',
-    pagetitle => 'Connection to the World',
-    alerts    => [ 'bigloss', 'noloss' ],
+  menu      => 'World',
+  pagetitle => 'Connection to the World',
+  alerts    => [ 'bigloss', 'noloss' ],
 }
 
 smokeping::target { 'GoogleCH':
-    hierarchy_parent => 'World',
-    hierarchy_level  => 2,
-    menu             => 'google.ch',
-    pagetitle        => 'Google',
+  hierarchy_parent => 'World',
+  hierarchy_level  => 2,
+  menu             => 'google.ch',
+  pagetitle        => 'Google',
 }
+
 smokeping::target { 'GoogleCHIPv4':
-    hierarchy_parent => 'GoogleCH',
-    hierarchy_level  => 3,
-    menu             => 'google.ch IPv4',
-    host             => 'google.ch',
-    slaves           => ['slave1'],
+  hierarchy_parent => 'GoogleCH',
+  hierarchy_level  => 3,
+  menu             => 'google.ch IPv4',
+  host             => 'google.ch',
+  slaves           => ['slave1'],
 }
+
 smokeping::target { 'GoogleCHIPv6':
-    hierarchy_parent => 'GoogleCH',
-    hierarchy_level  => 3,
-    menu             => 'google.ch IPv6',
-    host             => 'google.ch',
-    probe            => 'FPing6',
-    slaves           => ['slave1'],
+  hierarchy_parent => 'GoogleCH',
+  hierarchy_level  => 3,
+  menu             => 'google.ch IPv6',
+  host             => 'google.ch',
+  probe            => 'FPing6',
+  slaves           => ['slave1'],
 }
+
 smokeping::target { 'GoogleCHCurl':
-    hierarchy_parent => 'GoogleCH',
-    hierarchy_level  => 3,
-    menu             => 'google.ch Curl',
-    host             => 'google.ch',
-    probe            => 'Curl',
-    options          => {
-      urlformat => 'http://%host%/',
-    }
+  hierarchy_parent => 'GoogleCH',
+  hierarchy_level  => 3,
+  menu             => 'google.ch Curl',
+  host             => 'google.ch',
+  probe            => 'Curl',
+  options          => {
+    urlformat => 'http://%host%/',
+  },
 }
 ```
 
@@ -148,10 +164,10 @@ smokeping::target { 'GoogleCHCurl':
 
 The module is written by
 
-* Tobias Brunner <tobias@tobru.ch>
+- Tobias Brunner <tobias@tobru.ch>
 
 Licensed under Apache License, Version 2.0, Copyright 2015 by Tobias Brunner
 
 ## Contibutors
 
-See: [Github Contributors](https://github.com/tobru/puppet-smokeping/graphs/contributors)
+See: [Github Contributors](https://github.com/voxpupuli/puppet-smokeping/graphs/contributors)

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -1,5 +1,7 @@
 # Manage Apache config
 class smokeping::apache {
+  assert_private()
+
   $servername = $smokeping::servername
 
   $docroot = $facts['os']['family'] ? {

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -1,4 +1,4 @@
-# Manage Apache config
+# @summary Manage Apache config
 class smokeping::apache {
   assert_private()
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -115,13 +115,6 @@ class smokeping::config {
         display_name => $display_name,
         color        => $slave_color,
       }
-      # periodic restart to pick-up new config
-      #cron {
-      #  'smokeping::periodic-restart':
-      #    command => 'PATH=$PATH:/sbin /etc/init.d/smokeping stop >/dev/null 2>&1; sleep 2; PATH=$PATH:/sbin /etc/init.d/smokeping start >/dev/null 2>&1',
-      #    user    => root,
-      #    minute  => '*/15';
-      #}
     }
     ## Master/Standalone configuration
     ## collect slaves if mode is master and create Targets

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,4 +1,6 @@
 class smokeping::config {
+  assert_private()
+
   $mode          = $smokeping::mode
   $master_url    = $smokeping::master_url
   $shared_secret = $smokeping::shared_secret

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,3 +1,4 @@
+# @summary Manage SmokePing configuration
 class smokeping::config {
   assert_private()
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,139 +1,127 @@
-# == Class: smokeping
+# @summary Manage SmokePing
 #
-# A module to manage smokeping
+# @param mode
+#   SmokePing mode: master, slave, or standalone
 #
-# === Parameters
-# [*mode*]
-#   SmokePing mode: master or slave or standalone (Default: master on ubuntu, standalone on redhat)
+# @param master_url
+#   URL to master cgi for slave mode
 #
-# [*master_url*]
-#   URL to master cgi for slave mode (Default: http://somewhere/cgi-bin/smokeping.cgi)
+# @param shared_secret
+#   Path to slavesecrets file
 #
-# [*shared_secret*]
-#   Path to slavesecrets file (Default: /etc/smokeping/slavesecrets.conf)
+# @param slave_secrets
+#   Path to smokeping_secrets file
 #
-# [*slave_secrets*]
-#   Path to smokeping_secrets file (Default: /etc/smokeping/smokeping_secrets)
+# @param slave_name
+#   Name of slave. Only used in slave mode
 #
-# [*slave_name*]
-#   Name of slave. Only used in slave mode (Default: slave1)
+# @param slave_dir
+#   Path to slave definitions on master
 #
-# [*slave_dir*]
-#   Path to slave definitions on master (Default: /etc/smokeping/config.d/slaves.d)
+# @param slave_location
+#   Location of slave
 #
-# [*slave_location*]
-#   Location of slave (Default: '')
+# @param slave_display_name
+#   Name of slave, displayed on Webpage
 #
-# [*slave_display_name*]
-#   Name of slave, displayed on Webpage (Default: '')
+# @param slave_color
+#   Color of slave in the graph
 #
-# [*slave_color*]
-#   Color of slave in the graph (Default: '')
+# @param master_name
+#   Name of the master, in case of more than one SmokePing Master/Slave
 #
-# [*master_name*]
-#   Name of the master, in case of more than one SmokePing Master/Slave (Default: default)
+# @param owner
+#   Owner of this SmokePing instance
 #
-# [*owner*]
-#   Owner of this SmokePing instance (Default: Peter Random)
+# @param contact
+#   Contact E-Mail of this SmokePing instance
 #
-# [*contact*]
-#   Contact E-Mail of this SmokePing instance (Default: some@address.nowhere)
+# @param mailhost
+#   Where to send mails to
 #
-# [*mailhost*]
-#   Where to send mails to (Default: my.mail.host)
+# @param cgiurl
+#   URL of SmokePing CGI
 #
-# [*cgiurl*]
-#   URL of SmokePing CGI (Default: http://some.url/smokeping.cgi)
+# @param syslogfacility
+#   Syslog Facility
 #
-# [*syslogfacility*]
-#   Syslog Facility (Default: local0)
+# @param probes
+#   Probe definitions as Array of Hashes
 #
-# [*probes*]
-#   Probe definitions as Array of Hashes (Default: { name => 'FPing', binary => '/usr/bin/fping' })
+# @param default_probe
+#   Default Probe
 #
-# [*default_probe*]
-#   Default Probe (Default: FPing)
+# @param alerts_to
+#   E-Mail address or tool to send Alerts to
 #
-# [*alerts_to*]
-#   E-Mail address or tool to send Alerts to (Default: alertee@address.somewhere)
+# @param alerts_from
+#   Sender E-Mail of Alerts
 #
-# [*alerts_from*]
-#   Sender E-Mail of Alerts (Default: smokealert@company.xy)
+# @param alerts
+#   Alert definitions as Array of Hashes
 #
-# [*alerts*]
-#   Alert definitions as Array of Hashes (Default:
-#   { name          => 'someloss',
-#     alert_type    => 'loss',
-#     pattern       => '>0%,*12*,>0%,*12*,>0%',
-#     comment       => 'loss 3 times in a row' } )
+# @param cgi_remark_top
+#   Remark on Website
 #
-# [*cgi_remark_top*]
-#   Remark on Website (Default: Welcome to the SmokePing website of xxx Company. Here you will learn all about the latency of our network.)
+# @param cgi_title_top
+#   Title on Website
 #
-# [*cgi_title_top*]
-#   Title on Website (Default: Network Latency Grapher)
+# @param targets_dir
+#   Where to save target definitions
 #
-# [*targets_dir*]
-#   Where to save target definitions (Default: /etc/smokeping/config.d/targets.d)
+# @param targets
+#   Target definitions as a Hash of Smokeping::Target
 #
-# [*targets*]
-#   Target definitions as a Hash of Smokeping::Target (Default: {})
+# @param daemon_user
+#   User to run SmokePing
 #
-# [*daemon_user*]
-#   User to run SmokePing (Default: smokeping)
+# @param daemon_group
+#   Group of SmokePing
 #
-# [*daemon_group*]
-#   Group of SmokePing (Default: smokeping)
+# @param path_sendmail
+#   Path to sendmail binary
 #
-# [*path_sendmail*]
-#   Path to sendmail binary (Default: /usr/sbin/sendmail)
+# @param webserver_user
+#   User of webserver, owner of image-files
 #
-# [*webserver_user*]
-#   User of webserver, owner of image-files  (Default: www-data)
+# @param webserver_group
+#   Group of webserver
 #
-# [*webserver_group*]
-#   Group of webserver (Default: www-data)
+# @param path_imgcache
+#   Path to image cache dir
 #
-# [*path_imgcache*]
-#   Path to image cache dir (Default: /var/cache/smokeping/images)
+# @param path_imgurl
+#   URL path to images for CGI
 #
-# [*path_imgurl*]
-#   URL path to images for CGI (Default: ../smokeping/images)
+# @param path_datadir
+#   Path to smokeping data
 #
-# [*path_datadir*]
-#   Path to smokeping data (Default: /var/lib/smokeping)
+# @param path_piddir
+#   Path to PID file
 #
-# [*path_piddir*]
-#   Path to PID file (Default: /var/run/smokeping)
+# @param path_smokemail
+#   Path to smokemail binary
 #
-# [*path_smokemail*]
-#   Path to smokemail binary (Default: /etc/smokeping/smokemail)
+# @param path_tmail
+#   Path to tmail binary
 #
-# [*path_tmail*]
-#   Path to tmail binary (Default: /etc/smokeping/tmail)
+# @param version
+#   Version which should be installed
 #
-# [*version*]
-#   Version which should be installed (Default: present)
+# @param enable
+#   Should the service be enabled during boot time?
 #
-# [*enable*]
-#   Should the service be enabled during boot time? (Default: true)
+# @param start
+#   Should the service be started by Puppet?
 #
-# [*start*]
-#   Should the service be started by Puppet? (Default: true)
+# @param manage_apache
+#   Should we manage the Apache config with puppetlabs/apache?
 #
-# [*manage_apache*]
-#   Should we manage the Apache config with puppetlabs/apache? (Default: false)
+# @param manage_firewall
+#   Should we manage a firewall rule for Smokeping with puppetlabs/firewall?
 #
-# [*manage_firewall*]
-#   Should we manage a firewall rule for Smokeping with puppetlabs/firewall? (Default: false)
-#
-# [*manage_selinux*]
-#   Should we load an SELinux policy to allow Smokeping to work on Red Hat distros? (Default: false)
-#
-# === Author
-#
-# Tobias Brunner <tobias.brunner@nine.ch>
-#
+# @param manage_selinux
+#   Should we load an SELinux policy to allow Smokeping to work on Red Hat distros?
 class smokeping (
   $mode               = $smokeping::params::mode,
   $master_url         = $smokeping::params::master_url,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,3 +1,4 @@
+# @summary Manage SmokePing installation
 class smokeping::install {
   assert_private()
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,4 +1,6 @@
 class smokeping::install {
+  assert_private()
+
   package { 'smokeping':
     ensure => $smokeping::version,
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,8 +1,4 @@
-# == Class: smokeping::params
-#
-# This class manages Smokeping parameters.
-#
-
+# @summary SmokePing parameters
 class smokeping::params {
   assert_private()
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,8 @@
 #
 
 class smokeping::params {
+  assert_private()
+
   $version            = 'present'
   $enable             = true
   $start              = true

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,4 +1,6 @@
 class smokeping::service {
+  assert_private()
+
   $ensure = $smokeping::start ? {
     true    => running,
     false   => stopped,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,3 +1,4 @@
+# @summary Manage SmokePing service
 class smokeping::service {
   assert_private()
 

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -1,17 +1,16 @@
-# === Parameters
+# @summary SmokePing slave
 #
-# [*slave*]
+# @param slave
 #   Location of slave
 #
-# [*display_name*]
+# @param display_name
 #   Name of the slave
 #
-# [*color*]
+# @param color
 #   Color of this slave
 #
-# [*master*]
-#   Name of the smokeping master, in case there are more than one. (Default: default)
-#
+# @param master
+#   Name of the smokeping master, in case there are more than one.
 define smokeping::slave (
   $location,
   $display_name,

--- a/manifests/target.pp
+++ b/manifests/target.pp
@@ -1,34 +1,34 @@
-# === Parameters
-# [*pagetitle*]
+# @summary SmokePing target
+#
+# @param pagetitle
 #   Title. If empty, menu will be used as Title
 #
-# [*menu*]
+# @param menu
 #   Menu name.
 #
-# [*hierarchy_level*]
-#   Level of this target on the menu hierarchy. (Default: 1)
+# @param hierarchy_level
+#   Level of this target on the menu hierarchy.
 #
-# [*hierarchy_parent*]
-#   If hierarchy_level > 1, this specifies the parent
+# @param hierarchy_parent
+#   If hierarchy_level > 1, this specifies the parent.
 #
-# [*probe*]
+# @param probe
 #   Which probe to use.
 #
-# [*host*]
+# @param host
 #   Target host name/IP.
 #
-# [*alerts*]
+# @param alerts
 #   Array of Alerts to apply to this target
 #
-# [*slaves*]
+# @param slaves
 #   Array of slaves on which to run this target
 #
-# [*nomasterpoll*]
+# @param nomasterpoll
 #   Disable data-polling from master
 #
-# [*remark*]
+# @param remark
 #   Remark displayed on Website
-#
 define smokeping::target (
   Optional[String[1]] $pagetitle        = undef,
   Optional[String[1]] $menu             = undef,


### PR DESCRIPTION
Lint, update wording and links, use standard Puppet formatting.