### PR TITLE
Add `default_slaves` parameter for the `Targets` section

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -70,6 +70,7 @@ The following parameters are available in the `smokeping` class:
 * [`manage_selinux`](#-smokeping--manage_selinux)
 * [`package_perldoc`](#-smokeping--package_perldoc)
 * [`syslogpriority`](#-smokeping--syslogpriority)
+* [`default_slaves`](#-smokeping--default_slaves)
 * [`servername`](#-smokeping--servername)
 
 ##### <a name="-smokeping--mode"></a>`mode`
@@ -405,6 +406,14 @@ Data type: `String[1]`
 
 
 Default value: `'info'`
+
+##### <a name="-smokeping--default_slaves"></a>`default_slaves`
+
+Data type: `Array[String[1]]`
+
+
+
+Default value: `[]`
 
 ##### <a name="-smokeping--servername"></a>`servername`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -29,11 +29,6 @@ class smokeping::config {
   $alerts_from = $smokeping::alerts_from
   $alerts      = $smokeping::alerts
 
-  # Targets
-  $default_probe  = $smokeping::default_probe
-  $cgi_remark_top = $smokeping::cgi_remark_top
-  $cgi_title_top  = $smokeping::cgi_title_top
-
   # Pathnames
   $path_sendmail  = $smokeping::path_sendmail
   $path_imgcache  = $smokeping::path_imgcache
@@ -154,7 +149,7 @@ class smokeping::config {
       concat::fragment { 'targets-header':
         target  => '/etc/smokeping/config.d/Targets',
         order   => 10,
-        content => template('smokeping/targets-header.erb'),
+        content => epp("${module_name}/targets-header.epp"),
       }
 
       $smokeping::targets.each |$key, $value| {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -149,6 +149,7 @@ class smokeping (
   String[1] $syslogpriority = 'info',
   Array[Hash] $probes = [],
   String[1] $default_probe = 'FPing',
+  Array[String[1]] $default_slaves = [],
   Stdlib::Email $alerts_to = 'root@localhost',
   Stdlib::Email $alerts_from = 'root@localhost',
   Array[Hash] $alerts = [

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -36,6 +36,15 @@ describe 'smokeping' do
         it { is_expected.to contain_smokeping__slave(facts[:hostname]).with_color(0xabcdef) }
         it { is_expected.to contain_systemd__dropin_file('slave.conf').with_unit('smokeping.service') }
       end
+
+      context 'with default slaves' do
+        let :params do
+          super().merge(default_slaves: %w[slv1 slv2])
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat__fragment('targets-header').with_content(%r{slaves = slv1 slv2}) }
+      end
     end
   end
 end

--- a/templates/targets-header.epp
+++ b/templates/targets-header.epp
@@ -1,0 +1,11 @@
+*** Targets ***
+
+probe = <%= $smokeping::default_probe %>
+
+<% unless $smokeping::default_slaves.empty() { %>
+slaves = <%= $smokeping::default_slaves.join(' ') %>
+<% } %>
+
+menu = Top
+title = <%= $smokeping::cgi_title_top %>
+remark = <%= $smokeping::cgi_remark_top %>

--- a/templates/targets-header.erb
+++ b/templates/targets-header.erb
@@ -1,8 +1,0 @@
-*** Targets ***
-
-probe = <%= @default_probe %>
-
-menu = Top
-title = <%= @cgi_title_top %>
-remark = <%= @cgi_remark_top %>
-


### PR DESCRIPTION
This adds an optional `default_slaves` parameter that sets the `slaves` value at the top level of the `Targets` section of the smokeping config. The top-level `slaves` value is inherited by all of the targets, but can be overridden in individual targets.

Contains #142.