### PR TITLE
Don't manage datadir

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,6 +122,9 @@
 #
 # @param manage_selinux
 #   Should we load an SELinux policy to allow Smokeping to work on Red Hat distros?
+#
+# @param manage_datadir
+#   Should we manage the permissions on the data directory?
 class smokeping (
   Stdlib::HTTPUrl $cgiurl,
   Stdlib::HTTPUrl $master_url,
@@ -174,6 +177,7 @@ class smokeping (
   Boolean $manage_apache = false,
   Boolean $manage_firewall = false,
   Boolean $manage_selinux = false,
+  Boolean $manage_datadir = true,
   Stdlib::Fqdn $servername = $facts['networking']['fqdn'],
 ) {
   if $manage_apache {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,12 +14,14 @@ class smokeping::install {
   }
 
   # correct permissions
-  file { $smokeping::path_datadir:
-    ensure  => directory,
-    owner   => $smokeping::daemon_user,
-    group   => $smokeping::daemon_group,
-    require => Package['smokeping'],
-    recurse => true,
+  if $smokeping::manage_datadir {
+    file { $smokeping::path_datadir:
+      ensure  => directory,
+      owner   => $smokeping::daemon_user,
+      group   => $smokeping::daemon_group,
+      require => Package['smokeping'],
+      recurse => true,
+    }
   }
   file { $smokeping::path_piddir:
     ensure  => directory,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -24,6 +24,57 @@ describe 'smokeping' do
         it { is_expected.to contain_class('smokeping::install') }
         it { is_expected.to contain_class('smokeping::service') }
         it { is_expected.to contain_class('smokeping::config') }
+
+        case facts[:osfamily]
+        when 'RedHat'
+          it {
+            is_expected.to contain_file('/var/lib/smokeping/rrd').with(
+              ensure: 'directory',
+              owner: 'root',
+              group: 'root',
+              recurse: true
+            )
+          }
+        when 'Debian'
+          it {
+            is_expected.to contain_file('/var/lib/smokeping').with(
+              ensure: 'directory',
+              owner: 'smokeping',
+              group: 'smokeping',
+              recurse: true
+            )
+          }
+        end
+      end
+
+      context 'change datadir' do
+        let :params do
+          {
+            cgiurl: 'http://some.url/smokeping.cgi',
+            master_url: 'http://somewhere/cgi-bin/smokeping.cgi',
+            path_datadir: '/smokeping/data'
+          }
+        end
+
+        it {
+          is_expected.to contain_file('/smokeping/data').with(
+            ensure: 'directory',
+            recurse: true
+          )
+        }
+
+        context "don't manage datadir" do
+          let :params do
+            {
+              cgiurl: 'http://some.url/smokeping.cgi',
+              master_url: 'http://somewhere/cgi-bin/smokeping.cgi',
+              path_datadir: '/smokeping/data',
+              manage_datadir: false
+            }
+          end
+
+          it { is_expected.not_to contain_file('/smokeping/data') }
+        end
       end
     end
   end


### PR DESCRIPTION
This change adds a new manage_datadir argument to selectively
prevent the management of the data dir.

The scenario I ran into needing this was when using a master/slave
setup. The remote data comes in via Apache with the www-data user
and it requires a setfacl entry as documented at
https://github.com/oetiker/SmokePing/wiki/FAQ#master-slave-setups
or you'll see permission denied errors in the log file.

Ideally this module would be extended to support master/slave better,
but this will help in the meantime.