### PR TITLE
Fix params that are now default undef

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -101,17 +101,9 @@ class smokeping::config {
     'slave': {
       # Check if slave_display_name is unset.
       # --> use FQDN if not set.
-      if $smokeping::slave_display_name == '' {
-        $display_name = $facts['networking']['fqdn']
-      } else {
-        $display_name = $smokeping::slave_display_name
-      }
+      $display_name = pick($smokeping::slave_display_name, $facts['networking']['fqdn'])
 
-      if $smokeping::slave_color == '' {
-        $slave_color = sprintf('%06d', fqdn_rand('999999'))
-      } else {
-        $slave_color = $smokeping::slave_color
-      }
+      $slave_color = pick($smokeping::slave_color, sprintf('%06d', fqdn_rand('999999')))
 
       smokeping::slave { $facts['networking']['fqdn']:
         location     => $smokeping::slave_location,


### PR DESCRIPTION
In commit b025f408a6e78fa67c237b453211f29ad4778191 this module was
migrated from params to hiera. Some default params now have became
default undef, but in code we were still testing for default == ''.