### PR TITLE
Require stdlib 9.x

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,7 +6,7 @@ class smokeping::install {
     ensure => $smokeping::version,
   }
 
-  ensure_packages(
+  stdlib::ensure_packages(
     [
       'fping',
       $smokeping::package_perldoc,

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -23,7 +23,7 @@ define smokeping::slave (
     mode  => '0644',
   }
 
-  $random_value = fqdn_rand_string(60)
+  $random_value = stdlib::fqdn_rand_string(60)
 
   file { $smokeping::shared_secret:
     mode    => '0600',

--- a/metadata.json
+++ b/metadata.json
@@ -50,7 +50,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 7.0.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppet/systemd",


### PR DESCRIPTION
The non-namespaced functions are deprecated.