### PR TITLE
Fix specifying slave_name

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -109,7 +109,7 @@ Data type: `String[1]`
 
 Name of slave. Only used in slave mode
 
-Default value: `'slave1'`
+Default value: `$facts['networking']['hostname']`
 
 ##### <a name="-smokeping--slave_dir"></a>`slave_dir`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -71,7 +71,7 @@ class smokeping::config {
   ## mode specific
   case $mode {
     'slave': {
-      smokeping::slave { $facts['networking']['hostname']:
+      smokeping::slave { $smokeping::slave_name:
         location     => $smokeping::slave_location,
         display_name => pick($smokeping::slave_display_name, $facts['networking']['hostname']),
         color        => pick($smokeping::slave_color, fqdn_rand(0xffffff)),
@@ -80,7 +80,7 @@ class smokeping::config {
       $dropin = @("EOT")
         [Service]
         ExecStart=
-        ExecStart=/usr/sbin/smokeping --master-url=${smokeping::master_url} --cache-dir=${smokeping::path_datadir} --shared-secret=${smokeping::shared_secret} --pid-dir=/run/smokeping
+        ExecStart=/usr/sbin/smokeping --master-url=${smokeping::master_url} --cache-dir=${smokeping::path_datadir} --shared-secret=${smokeping::shared_secret} --slave-name=${smokeping::slave_name} --pid-dir=/run/smokeping
         | EOT
 
       systemd::dropin_file { 'slave.conf':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -142,7 +142,7 @@ class smokeping (
   Enum['master', 'slave', 'standalone'] $mode,
   Stdlib::Absolutepath $shared_secret = '/etc/smokeping/slavesecrets.conf',
   Stdlib::Absolutepath $slave_secrets = '/etc/smokeping/smokeping_secrets',
-  String[1] $slave_name = 'slave1',
+  String[1] $slave_name = $facts['networking']['hostname'],
   Stdlib::Absolutepath $slave_dir = '/etc/smokeping/config.d/slaves.d',
   Optional[String[1]] $slave_location = undef,
   Optional[String[1]] $slave_display_name = undef,

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -35,7 +35,7 @@ define smokeping::slave (
   @@concat::fragment { "${facts['networking']['fqdn']}-secret":
     target  => $smokeping::slave_secrets,
     order   => 10,
-    content => "${facts['networking']['hostname']}:${random_value}\n",
+    content => "${title}:${random_value}\n",
     tag     => "smokeping-slave-secret-${master}",
   }
 


### PR DESCRIPTION
Setting slave_name didn't have any affect as this was hard coded to the hosts hostname. Change it to allow setting the slave_name and default to hostname.

