### PR TITLE
Allow puppet/systemd 9.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -53,7 +53,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 3.5.1 < 9.0.0"
+      "version_requirement": ">= 3.5.1 < 10.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
- **Drop support for EOL Debian 10 and Ubuntu 20.04**
- **Allow puppet/systemd 9.x**
